### PR TITLE
Single builtin cmd-> exec in parent process ; all others -> exec in child process

### DIFF
--- a/head/minishell.h
+++ b/head/minishell.h
@@ -24,6 +24,7 @@
 # include <readline/history.h>
 # include <readline/readline.h>
 #include <sys/errno.h>
+#include <stdbool.h>
 
 typedef struct s_str_list
 {

--- a/src/execute_cmd.c
+++ b/src/execute_cmd.c
@@ -16,7 +16,10 @@
 void	execute_cmd(t_cmd cmd, int to_read, int to_write)
 {
 	if(cmd.argv && is_builtin(cmd.argv[0]) >= 0)
-		exit(EXIT_SUCCESS);
+	{
+		exec_builtin(&cmd, to_write);
+		exit (ft_atoi((const char *)envp_lst->content)) ;
+	}
 	if (to_read != STDIN_FILENO)
 	{
 		dup2(to_read, STDIN_FILENO);

--- a/src/execute_cmd_line.c
+++ b/src/execute_cmd_line.c
@@ -21,6 +21,8 @@ void get_fds(t_cmdlist *cmd_lst, int pipes[10240][2], int i, int *fd_to_read, in
 
 void close_fds(int fd_to_read, int fd_to_write);
 
+bool is_single_builtin_cmd(t_cmdlist *cmd_lst);
+
 int	execute_cmd_line(t_cmdlist *cmd_lst)
 {
 	int	pipes[OPEN_MAX][2];
@@ -30,6 +32,8 @@ int	execute_cmd_line(t_cmdlist *cmd_lst)
 	int	i;
 
 	i = 0;
+	if (is_single_builtin_cmd(cmd_lst))
+		return(exec_builtin(cmd_lst->content, 1), 1);
 	while (cmd_lst)
 	{
 		check_path(cmd_lst);
@@ -44,11 +48,6 @@ int	execute_cmd_line(t_cmdlist *cmd_lst)
 			execute_cmd(*cmd_lst->content,\
 			fd_to_read,\
 			fd_to_write);
-		if (!cmd_lst->content->heredoc_mode && (cmd_lst->content)->argv &&\
-		is_builtin((cmd_lst->content)->argv[0]) >= 0 )
-			exec_builtin(cmd_lst->content, \
-
-						 fd_to_write);
 		close_fds(fd_to_read, fd_to_write);
 		if ((cmd_lst->content)->heredoc_mode)
 			close((cmd_lst->content)->heredoc_pipe[READ]);
@@ -56,6 +55,14 @@ int	execute_cmd_line(t_cmdlist *cmd_lst)
 		i++;
 	}
 	return (exit_routine(pipes, pids, i), free_cmd_lst(&cmd_lst), 1);
+}
+
+bool is_single_builtin_cmd(t_cmdlist *cmd_lst) {
+	if (!cmd_lst->next)
+		if (cmd_lst->content->argv)
+			if (is_builtin(cmd_lst->content->argv[0]))
+				return (true);
+	return (false);
 }
 
 void close_fds(int fd_to_read, int fd_to_write) {


### PR DESCRIPTION
```sh
 ➜ export a=12 | echo $a
 ➜
```
As you can see, thoses builtins are now executed in separated child process ! $a is not created

```sh
 ➜ export a=12
 ➜ echo $a
12
 ➜
```
On the other hand, those commands line are composed of only one builtin per command, nothing else.
That's why those commands are executed in the parent process.
Here, $a exist, it's value is 12.

The lasts commands have follow the following (new) code :

_execute_cmd_line.c :_
```c
35	if (is_single_builtin_cmd(cmd_lst))
36		return(exec_builtin(cmd_lst->content, 1), 1);
```
